### PR TITLE
fix: prevent nested Claude Code session error

### DIFF
--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -202,10 +202,11 @@ export class SessionManager {
     //    tmux set-environment는 새 pane에만 적용되므로,
     //    초기 셸에는 send-keys로 직접 export해야 합니다.
     try {
+      const unsetNested = 'unset CLAUDECODE CLAUDE_CODE; '
       const envExport = this.ipcDir
         ? `export MULAUDE_SESSION_ID='${id}' MULAUDE_IPC_DIR='${this.ipcDir}'; `
         : ''
-      sendKeysToTmux(tmuxPath, tmuxName, envExport + this.claudePath)
+      sendKeysToTmux(tmuxPath, tmuxName, unsetNested + envExport + this.claudePath)
     } catch (err) {
       console.error(`[SessionManager] tmux send-keys failed:`, err)
       killTmuxSession(tmuxPath, tmuxName)

--- a/src/main/tmux-utils.ts
+++ b/src/main/tmux-utils.ts
@@ -149,24 +149,28 @@ export function createTmuxSession(
     timeout: TMUX_SESSION_CREATE_TIMEOUT
   })
 
-  // 2) 환경변수 주입 (개별 실패 무시)
+  // 2) 중첩 세션 방지: CLAUDECODE 환경변수 제거
+  execTmux(tmuxPath, ['set-environment', '-t', name, '-u', 'CLAUDECODE'])
+  execTmux(tmuxPath, ['set-environment', '-t', name, '-u', 'CLAUDE_CODE'])
+
+  // 3) 환경변수 주입 (개별 실패 무시)
   for (const [key, value] of Object.entries(envVars)) {
     if (execTmux(tmuxPath, ['set-environment', '-t', name, key, value]) === null) {
       console.warn(`[tmux-utils] set-environment failed for ${key}`)
     }
   }
 
-  // 3) 스크롤백 버퍼 확장
+  // 4) 스크롤백 버퍼 확장
   if (execTmux(tmuxPath, ['set-option', '-t', name, 'history-limit', String(TMUX_HISTORY_LIMIT)]) === null) {
     console.warn('[tmux-utils] set history-limit failed')
   }
 
-  // 4) tmux 상태바 비활성화 (xterm.js에서 중복 렌더링 방지)
+  // 5) tmux 상태바 비활성화 (xterm.js에서 중복 렌더링 방지)
   if (execTmux(tmuxPath, ['set-option', '-t', name, 'status', 'off']) === null) {
     console.warn('[tmux-utils] set status off failed')
   }
 
-  // 5) 마우스 모드 활성화 (스크롤 이벤트를 tmux가 처리하도록)
+  // 6) 마우스 모드 활성화 (스크롤 이벤트를 tmux가 처리하도록)
   //    alt buffer에서 xterm.js가 wheel을 화살표 키로 변환하는 문제 방지
   if (execTmux(tmuxPath, ['set-option', '-t', name, 'mouse', 'on']) === null) {
     console.warn('[tmux-utils] set mouse failed')


### PR DESCRIPTION
## Summary
- When Mulaude is launched from within a Claude Code session, the tmux session inherits the `CLAUDECODE` env var from the parent process, causing `"Claude Code cannot be launched inside another Claude Code session"` error
- Remove `CLAUDECODE`/`CLAUDE_CODE` from tmux session environment via `set-environment -u`
- Unset `CLAUDECODE`/`CLAUDE_CODE` in initial shell before launching claude via `send-keys`

## Test plan
- [ ] Launch Mulaude from within a Claude Code session
- [ ] Create a new project/session
- [ ] Verify Claude Code starts without nested session error