### PR TITLE
fix: 패키징 앱에서 preview-launcher가 pnpm/npm 못 찾는 문제 수정

### DIFF
--- a/src/main/preview-launcher.ts
+++ b/src/main/preview-launcher.ts
@@ -26,6 +26,14 @@ import { join } from 'path'
 import { createConnection } from 'net'
 import { BrowserWindow } from 'electron'
 import { PREVIEW_SIGTERM_GRACE } from '../shared/constants'
+import { getShellEnv } from './env-resolver'
+
+/** 로그인 셸 환경변수 캐시 (Finder 실행 시 PATH 누락 방지) */
+let shellEnvCache: Record<string, string> | null = null
+function getCachedShellEnv(): Record<string, string> {
+  if (!shellEnvCache) shellEnvCache = getShellEnv()
+  return shellEnvCache
+}
 
 /* ─── Types ─── */
 
@@ -207,7 +215,7 @@ export async function launchPreview(sessionId: string, workingDir: string): Prom
         cwd,
         shell: true,
         stdio: ['ignore', 'pipe', 'pipe'],
-        env: { ...process.env, FORCE_COLOR: '0' }
+        env: { ...getCachedShellEnv(), FORCE_COLOR: '0' }
       })
 
       // stdout/stderr → 렌더러로 전송


### PR DESCRIPTION
## Summary
- 패키징된 앱(Finder 실행)에서 `process.env`에 셸 PATH가 포함되지 않아 `pnpm: command not found` 에러 발생
- `preview-launcher`의 spawn env를 `process.env` → `getShellEnv()`(로그인 셸 환경변수)로 교체
- `getShellEnv()` 결과를 모듈 레벨에서 캐싱하여 반복 호출 방지

## Test plan
- [ ] 패키징된 앱에서 미리보기 실행 시 `pnpm: command not found` 에러 미발생 확인
- [ ] dev 모드에서 미리보기 정상 작동 확인